### PR TITLE
moved lock icons into link

### DIFF
--- a/docs/how-we-work.md
+++ b/docs/how-we-work.md
@@ -22,42 +22,42 @@ As designers at Truss, we have a wealth of opportunities to both learn and deepe
 More brains are better than one, so we take every opportunity possible to share with and learn from other designers on our team. Here are some of the ways that unfolds:
 
 **Weekly huddles**  
-We meet for an hour every week to talk through team developments or trainings, share work, or run a workshop together. Notes from past huddles can always be found in 🔒[this shared document](https://docs.google.com/document/d/1PJLiesGhCTqUlT0mrg6PC9scS2SocV4hL98YJtscU0A/edit#heading=h.fmqjp8bk9qys).
+We meet for an hour every week to talk through team developments or trainings, share work, or run a workshop together. Notes from past huddles can always be found in [🔒 this shared document](https://docs.google.com/document/d/1PJLiesGhCTqUlT0mrg6PC9scS2SocV4hL98YJtscU0A/edit#heading=h.fmqjp8bk9qys).
 
 **Being humans time**  
-Every week, there is an optional 30 minutes on the calendar to get together with fellow designers and talk about not-work-related things. Because we don’t catch one another in the hallway or by the watercooler, this time is there to help us form those human-to-human connections necessary to do good work together. This is something we do [at the company-level](https://guide.truss.works/#meeting-being-humans-together-bht) and occasionally at the project-level, too. Anyone is welcome to throw out a topic (🔒[see this list for ideas](https://docs.google.com/document/d/1GiOphvQlVfHHxhujq_pTEHMA1Ef2JZnpZq0Hm8tttQM/edit)), but be forewarned that with this group, there’s probably a 50% chance it will end up being food-related.
+Every week, there is an optional 30 minutes on the calendar to get together with fellow designers and talk about not-work-related things. Because we don’t catch one another in the hallway or by the watercooler, this time is there to help us form those human-to-human connections necessary to do good work together. This is something we do [at the company-level](https://guide.truss.works/#meeting-being-humans-together-bht) and occasionally at the project-level, too. Anyone is welcome to throw out a topic ([🔒 see this list for ideas](https://docs.google.com/document/d/1GiOphvQlVfHHxhujq_pTEHMA1Ef2JZnpZq0Hm8tttQM/edit)), but be forewarned that with this group, there’s probably a 50% chance it will end up being food-related.
 
 **Critiques and share-outs**  
 We regularly share in-progress work for feedback and to learn from one another. Sometimes these are more formal critiques, and sometimes they’re just to share something interesting that might be useful to others. Past sessions that we’ve recorded can be found below:
 
-- 🔒[Organizing research with Airtable](https://drive.google.com/a/truss.works/file/d/1tZNWLjB85RihYYyai--5miISmSdis05-/view?usp=sharing)  
+- [🔒 Organizing research with Airtable](https://drive.google.com/a/truss.works/file/d/1tZNWLjB85RihYYyai--5miISmSdis05-/view?usp=sharing)  
 by Monica; June 2019 - Monica shared how she tagged and organized research for the CMS-West project using Airtable.
 
-- 🔒[MilMove design tooling workflow](https://drive.google.com/a/truss.works/file/d/1MF6ixDfd4wDzM2yS7n7uvKDKnpC3kHbJ/view?usp=sharing)  
+- [🔒 MilMove design tooling workflow](https://drive.google.com/a/truss.works/file/d/1MF6ixDfd4wDzM2yS7n7uvKDKnpC3kHbJ/view?usp=sharing)  
 by Derrick; June 2019 - Derrick showed us his proposal for a new toolset and workflow for the MilMove design team.
 
-- 🔒[MilMove training materials](https://drive.google.com/a/truss.works/file/d/14TImI4zjDnKWON36bQKyeYpAVmHLXmu5/view?usp=sharing)  
+- [🔒 MilMove training materials](https://drive.google.com/a/truss.works/file/d/14TImI4zjDnKWON36bQKyeYpAVmHLXmu5/view?usp=sharing)  
 by James; July 2019 - James walked through his process for creating training materials for users of MilMove and shared drafts of in-progress documentation.
 
-- 🔒[SABER discovery roadmap](https://drive.google.com/a/truss.works/file/d/1dH0Zt6ImRr8dwBmQrzc3qmRLHxJONOmS/view?usp=sharing)  
+- [🔒 SABER discovery roadmap](https://drive.google.com/a/truss.works/file/d/1dH0Zt6ImRr8dwBmQrzc3qmRLHxJONOmS/view?usp=sharing)  
 by Karen; July 2019 - Karen walked through the roadmap she designed in Miro to kickoff the SABER project and outline the Discovery and Framing period.
 
-- 🔒[Design method cards](https://drive.google.com/a/truss.works/file/d/1olCwy7qYlBiX6CzBBiLvH3cvNlBpDZbV/view?usp=sharing)  
+- [🔒 Design method cards](https://drive.google.com/a/truss.works/file/d/1olCwy7qYlBiX6CzBBiLvH3cvNlBpDZbV/view?usp=sharing)  
 by Mariesa; August 2019 - Mariesa shared her first draft of method cards for commonly used design activities and workshops.
 
-- 🔒[Intro to GitHub](https://drive.google.com/a/truss.works/file/d/1ADxbCSorzedx89SrutYXa35ut1s4AM69/view?usp=sharing)  
+- [🔒 Intro to GitHub](https://drive.google.com/a/truss.works/file/d/1ADxbCSorzedx89SrutYXa35ut1s4AM69/view?usp=sharing)  
 by Josh; September 2019 - Josh took the team through a simple GitHub workflow so folks could get more familiar with a tool used widely across the Truss org.
 
-- 🔒[Outcome-based roadmapping](https://drive.google.com/a/truss.works/file/d/1TZlKM2mOoATTi1oy3HqcUDAOhVNFzcZL/view?usp=sharing)  
+- [🔒 Outcome-based roadmapping](https://drive.google.com/a/truss.works/file/d/1TZlKM2mOoATTi1oy3HqcUDAOhVNFzcZL/view?usp=sharing)  
 by Monica; December 2019 - Monica shared how the team on EASi transitioned out of the discovery period and into delivery by aligning on strategic outcomes using lean value trees.
 
-- 🔒[Code for America workshop](https://drive.google.com/a/truss.works/file/d/1GGN_FOwzgjFcvD6dy7X0ZIDPJwTnq9T_/view?usp=sharing)  
+- [🔒 Code for America workshop](https://drive.google.com/a/truss.works/file/d/1GGN_FOwzgjFcvD6dy7X0ZIDPJwTnq9T_/view?usp=sharing)  
 by Carmen and Monica; February 2020 - In preparation for the Code for America conference, Carmen and Monica walked us through their draft workshop, Practical Design Thinking and User-Centered Design for Moving the Needle in Government.
 {: .mb-7}
 
 ## Bringing design perspective to Truss committees, guilds, and working groups
 
-Truss has a number of 🔒[auxiliary groups](https://docs.google.com/document/d/1NwQ3N9Zzy0O_KmprdwtAovEwZDGT3TeCdr9rggzu-zI/edit?ts=5d44d762#heading=h.8oxflvtts2qi) where you can lend your time and expertise to help improve the organization. You can easily find these groups by searching “c-” for committees, “g-” for guilds, and “wg-” for working groups in Slack.
+Truss has a number of [🔒 auxiliary groups](https://docs.google.com/document/d/1NwQ3N9Zzy0O_KmprdwtAovEwZDGT3TeCdr9rggzu-zI/edit?ts=5d44d762#heading=h.8oxflvtts2qi) where you can lend your time and expertise to help improve the organization. You can easily find these groups by searching “c-” for committees, “g-” for guilds, and “wg-” for working groups in Slack.
 
 Here are some examples of the committees, guilds, and working groups designers have joined or contributed to in the past:
 
@@ -76,9 +76,9 @@ Here are some examples of the committees, guilds, and working groups designers h
 
 We are fortunate to have a business development team that prioritizes practitioner participation and input in the sales process. All scoping calls with prospective commercial clients include a member of the design team so that we can ensure someone from the practice can vet the opportunity, understand the needs of the client, help determine staffing, and assist with writing the proposal.
 
-Monica helped our business development team design a more 🔒[streamlined user flow](https://miro.com/app/board/o9J_kxMVVlU=/) that details every client and internal touchpoint from the prospect stage to getting the deal signed. The 🔒[Involving Trussels in CommSales Playbook](https://docs.google.com/document/d/1353rTQtvgDz__FDffN2KTHT58R1DN_qKNo9vtU2ixTI/edit#) outlines exactly when designers get brought into the sales process, what the expectations are, and the current list of folks who are designated to assist with this effort.
+Monica helped our business development team design a more [🔒 streamlined user flow](https://miro.com/app/board/o9J_kxMVVlU=/) that details every client and internal touchpoint from the prospect stage to getting the deal signed. The [🔒 Involving Trussels in CommSales Playbook](https://docs.google.com/document/d/1353rTQtvgDz__FDffN2KTHT58R1DN_qKNo9vtU2ixTI/edit#) outlines exactly when designers get brought into the sales process, what the expectations are, and the current list of folks who are designated to assist with this effort.
 
-We’ve also developed a 🔒[design-specific scoping guide](https://docs.google.com/document/d/1t00vZ-tBQM0dsop8EoUX7qZAnqzdFbpe93z58uqe3uQ/edit#heading=h.bc9uhdtcwc33) that details what makes a good project and what questions we should be asking the client in the scoping call to ensure it’s a good fit.
+We’ve also developed a [🔒 design-specific scoping guide](https://docs.google.com/document/d/1t00vZ-tBQM0dsop8EoUX7qZAnqzdFbpe93z58uqe3uQ/edit#heading=h.bc9uhdtcwc33) that details what makes a good project and what questions we should be asking the client in the scoping call to ensure it’s a good fit.
 {: .mb-7}
 
 ## Designing with teammates and clients on projects
@@ -86,19 +86,19 @@ We’ve also developed a 🔒[design-specific scoping guide](https://docs.google
 There is no “typical” project here at Truss, so there is no “typical” design playbook to run one, but there are some practices we hold near and dear, which we’ve started to formalize below:
 
 **Team norming**  
-Every new project is a new problem to solve and potentially a brand new mix of people to solve it with — which is why we care so deeply about team norming and building a foundation of trust. 🔒[Here are some of our favorite activities](https://miro.com/app/board/o9J_kt0cswE=/?moveToWidget=3074457347688302246&cot=13) to get to know each other, understand working styles, and norm on how we’ll work together.
+Every new project is a new problem to solve and potentially a brand new mix of people to solve it with — which is why we care so deeply about team norming and building a foundation of trust. [🔒 Here are some of our favorite activities](https://miro.com/app/board/o9J_kt0cswE=/?moveToWidget=3074457347688302246&cot=13) to get to know each other, understand working styles, and norm on how we’ll work together.
 
 - **BICEPS:** Understand what is important to each person working on the project and what motivates us.
 - **Superpowers and kryptonite:** Understand each person’s self-identified strengths and areas for growth/improvement.
 - **Contribute, lead, learn:** Understand the work areas each person wants to contribute to, lead, and learn more about.
 
-We’ve also found it helpful, as an output from these activities, to develop more 	🔒[formal workstreams](https://miro.com/app/board/o9J_kt0cswE=/?moveToWidget=3074457347687556976&cot=13) for everyone on the team that detail what they’re 
+We’ve also found it helpful, as an output from these activities, to develop more 	[🔒 formal workstreams](https://miro.com/app/board/o9J_kt0cswE=/?moveToWidget=3074457347687556976&cot=13) for everyone on the team that detail what they’re 
 responsible for leading, who they will collaborate with, and any potential risks.
 
 In addition to these activities, it is also critically important to discuss with the 
 entire internal team how decisions will be made, who will be involved, and how 
 they will be documented. Truss has a robust practice of using [decision records](https://github.com/joelparkerhenderson/architecture_decision_record) 
-to document decisions — which the 🔒[SABER design team adopted](https://github.com/trussworks/saber-research-design/wiki/Design-and-product-decision-records) and 
+to document decisions — which the [🔒 SABER design team adopted](https://github.com/trussworks/saber-research-design/wiki/Design-and-product-decision-records) and 
 recommends for future projects.
 
 **Discovery and framing**  
@@ -126,7 +126,7 @@ We think of D&F as a three-phased approach:
     - Synthesize findings and share recommendations
     - Create an outcome-based roadmap and project plan to move forward
 
-While every project approaches this work a little bit differently, there’s value in having a shared library of resources to pull from. While it’s still in progress, we have the beginnings of a 🔒[Project Kickoff Miro board](https://miro.com/app/board/o9J_kt0cswE=/?moveToWidget=3074457347687556824&cot=13) with easy-to-copy templates for many of the activities listed above. Additional [resources](../resources/resources) can be found in the Resources section of this playbook.
+While every project approaches this work a little bit differently, there’s value in having a shared library of resources to pull from. While it’s still in progress, we have the beginnings of a [🔒 Project Kickoff Miro board](https://miro.com/app/board/o9J_kt0cswE=/?moveToWidget=3074457347687556824&cot=13) with easy-to-copy templates for many of the activities listed above. Additional [resources](../resources/resources) can be found in the Resources section of this playbook.
 {: .mb-7}
 
 ## Sharing good design practices company-wide
@@ -135,26 +135,26 @@ In the life cycle of Truss, research and design is a relatively new practice, so
 
 Every Friday after our practitioner (full company) meeting, there is a 25 minute slot open for any Trussel to present on a topic to the rest of the Truss team. Below is a list of recordings of past One Topic Talks done by members of the design team:
 
-- **🔒[Introduction to content strategy ](https://drive.google.com/a/truss.works/file/d/12I-VKBBqUeLHIBrgIiNk0jBGQqrBNYfg/view?usp=sharing)**  
+- **[🔒 Introduction to content strategy ](https://drive.google.com/a/truss.works/file/d/12I-VKBBqUeLHIBrgIiNk0jBGQqrBNYfg/view?usp=sharing)**  
 by James and Kaleigh; January 2019 - A general overview of content strategy work, why it’s important, and what it looks like in practice.
 
-- **🔒[Stakeholder research and synthesis on CMS West](https://drive.google.com/a/truss.works/file/d/13jJnTHX4hA74-PA2N_S-BByMppQfffbV/view?usp=sharing)**  
+- **[🔒 Stakeholder research and synthesis on CMS West](https://drive.google.com/a/truss.works/file/d/13jJnTHX4hA74-PA2N_S-BByMppQfffbV/view?usp=sharing)**  
 by Karen; February 2019 - How user research was conducted on a very technical project with the Centers for Medicare & Medicaid Services.
 
-- **🔒[Truss brand guide](https://drive.google.com/a/truss.works/file/d/1wZB4V4tcrUU1RiGMoMjTHZyw8DbsyQbY/view?usp=sharing)**  
+- **[🔒 Truss brand guide](https://drive.google.com/a/truss.works/file/d/1wZB4V4tcrUU1RiGMoMjTHZyw8DbsyQbY/view?usp=sharing)**  
 by Josh; February 2019 - The official release of a visual brand guide and assets for Truss.
 
-- **🔒[Human-centered sales process](https://drive.google.com/a/truss.works/file/d/1QjBFYV5Jo9Rj8dpjMSY6R7TK_EEzVRaA/view?usp=sharing)**  
+- **[🔒 Human-centered sales process](https://drive.google.com/a/truss.works/file/d/1QjBFYV5Jo9Rj8dpjMSY6R7TK_EEzVRaA/view?usp=sharing)**  
 by Monica, Dom, and Jamie; September 2019 - How a human-centered approach helped improve Truss’s commercial sales process.
 
-- **🔒[Introduction to object-oriented UX](https://drive.google.com/a/truss.works/file/d/15g9lv3W5tYhPAQDPBnkepQOvZfpd0x-H/view?usp=sharing)**  
+- **[🔒 Introduction to object-oriented UX](https://drive.google.com/a/truss.works/file/d/15g9lv3W5tYhPAQDPBnkepQOvZfpd0x-H/view?usp=sharing)**  
 by Karen; October 2019 - An overview on object-oriented design and how to apply it to some of the work we do at Truss.
 
-- **🔒[Introduction to accessibility](https://drive.google.com/a/truss.works/file/d/1qCHg60RToi0p3RN-BfRo1lL7QnSTIOlq/view?usp=sharing)**  
+- **[🔒 Introduction to accessibility](https://drive.google.com/a/truss.works/file/d/1qCHg60RToi0p3RN-BfRo1lL7QnSTIOlq/view?usp=sharing)**  
 by Liz and Christine; December 2019 - An introduction to web accessibility, why it matters, and tools to ensure your work meets baseline accessibility standards.
 
-- **🔒[SABER research and design wiki walkthrough ](https://drive.google.com/a/truss.works/file/d/1UHbwAMMA7HZZdPPCNH9LZ1DtiqjBqfGg/view?usp=sharing)**  
-by Carmen, Kaleigh, and Josh; April 2020 - Walkthrough of the SABER design team’s 🔒[GitHub wiki](https://github.com/trussworks/saber-research-design/wiki) for research artifacts, decision records, and MVP work.
+- **[🔒 SABER research and design wiki walkthrough ](https://drive.google.com/a/truss.works/file/d/1UHbwAMMA7HZZdPPCNH9LZ1DtiqjBqfGg/view?usp=sharing)**  
+by Carmen, Kaleigh, and Josh; April 2020 - Walkthrough of the SABER design team’s [🔒 GitHub wiki](https://github.com/trussworks/saber-research-design/wiki) for research artifacts, decision records, and MVP work.
 
-- **🔒[Best practices for writing UI copy](https://docs.google.com/document/d/1Z7coDEBZjQ195TKlOdVFWWMmkFnVhQDv0_fFjnivmiM/edit#)** by James and Amanda. There was no recording of this OTT, but this document captures most of the content; namely, the key principles and best practices of writing good UI copy.
+- **[🔒 Best practices for writing UI copy](https://docs.google.com/document/d/1Z7coDEBZjQ195TKlOdVFWWMmkFnVhQDv0_fFjnivmiM/edit#)** by James and Amanda. There was no recording of this OTT, but this document captures most of the content; namely, the key principles and best practices of writing good UI copy.
 

--- a/docs/resources/templates.md
+++ b/docs/resources/templates.md
@@ -12,15 +12,15 @@ We have a growing collection of templates at our disposal for use across differe
 
 ## Research and workshops
 
-**🔒[Discovery & Framing Method Cards](https://drive.google.com/file/d/1If_bLbRyn4H8FmvIr7eBYKtu4AXcQ_Rj/view)** - We’ve created a set of method cards that outline possible Discovery and Framing activities. Each method provides the what, why, and when to use as well as a detailed explanation of the process for running it.
+**[🔒 Discovery & Framing Method Cards](https://drive.google.com/file/d/1If_bLbRyn4H8FmvIr7eBYKtu4AXcQ_Rj/view)** - We’ve created a set of method cards that outline possible Discovery and Framing activities. Each method provides the what, why, and when to use as well as a detailed explanation of the process for running it.
 
-**🔒[New project kickoff](https://miro.com/app/board/o9J_kt0cswE=/)** - This Miro board contains a growing number of activities that you can use during the kick off or inception of a new project.
+**[🔒 New project kickoff](https://miro.com/app/board/o9J_kt0cswE=/)** - This Miro board contains a growing number of activities that you can use during the kick off or inception of a new project.
 
-**🔒[Usability recruitment email template](https://drive.google.com/drive/u/0/folders/1qh4Ny2DRjsvrNLSx_GXZoOJkMXcUnmAv)** - Sample usability recruitment emails provided by [usability.gov](https://www.usability.gov/). There are templates for recruitment as well as confirmation of both in person and remote sessions.
+**[🔒 Usability recruitment email template](https://drive.google.com/drive/u/0/folders/1qh4Ny2DRjsvrNLSx_GXZoOJkMXcUnmAv)** - Sample usability recruitment emails provided by [usability.gov](https://www.usability.gov/). There are templates for recruitment as well as confirmation of both in person and remote sessions.
 
-**🔒[Usability findings template](https://docs.google.com/presentation/d/1vXfdELAda8Vhg58G0wLZb4f2oXoFzQFKbe6JibRSoaQ/edit#slide=id.g4c4243ba87_0_414)** - A sample usability finding template that outlines scope, synthesis, findings, and solutions exploration.
+**[🔒 Usability findings template](https://docs.google.com/presentation/d/1vXfdELAda8Vhg58G0wLZb4f2oXoFzQFKbe6JibRSoaQ/edit#slide=id.g4c4243ba87_0_414)** - A sample usability finding template that outlines scope, synthesis, findings, and solutions exploration.
 
-**🔒[Usability script template](https://docs.google.com/document/d/1GJ_DR_Zrho1cYNQRaMlkQ9Tz8aroVHy9Kci9-2898Z0/edit#heading=h.4uoggmftr6zl)** - A sample usability script template that outlines goals, flow, introductions, session setup, tasks, and follow up.
+**[🔒 Usability script template](https://docs.google.com/document/d/1GJ_DR_Zrho1cYNQRaMlkQ9Tz8aroVHy9Kci9-2898Z0/edit#heading=h.4uoggmftr6zl)** - A sample usability script template that outlines goals, flow, introductions, session setup, tasks, and follow up.
 {: .mb-7}
 
 ## Design systems


### PR DESCRIPTION
**Pages edited**
* How we work
* Templates

**Edits made**
Moved 🔒 lock emojis inside the link instead of outside to improve line break visuals

**Additional notes (optional)**
Before:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/764090/226752268-25577948-dba0-46d1-9f90-8e52b9e88b28.png">

After:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/764090/226752360-ea93391f-962d-4b96-8259-1193f9d83b82.png">
